### PR TITLE
Changed regexes to match output of gtest

### DIFF
--- a/gtpp.py
+++ b/gtpp.py
@@ -102,7 +102,8 @@ class Parser(object):
 
     def process(self, line):
         if not self.handler.process(self, line):
-            self.output.raw_output(self.current_test, line)
+            #self.output.raw_output(self.current_test, line)
+            pass
 
     @staticmethod
     def parse_time(time):

--- a/gtpp.py
+++ b/gtpp.py
@@ -111,14 +111,14 @@ class Parser(object):
         else:
             return None
 
-    @handler.add(r'Running (\d+) tests? from (\d+) test cases?')
+    @handler.add(r'Running (\d+) tests? from (\d+) test (?:cases?|suites?)')
     def start(self, total_test_count, total_test_case_count):
         self.total_test_count = int(total_test_count)
         self.total_test_case_count = int(total_test_case_count)
         self.in_test_suite = True
         self.is_summarizing_failures = False
 
-    @handler.add(r'(\d+) tests? from (\d+) test cases? ran. ?' + TIME_RE + '$')
+    @handler.add(r'(\d+) tests? from (\d+) test (?:cases?|suites?) ran. ?' + TIME_RE + '$')
     def finish(self, total_test_count, total_test_case_count, time):
         self.output.finish(int(total_test_count), int(total_test_case_count), self.parse_time(time))
         self.in_test_suite = False


### PR DESCRIPTION
I've seen that with different machines I've been running this on that googletest can either use "cases" or "suites" in it's output. I haven't dug into why this is the case but I think it depends upon how googletest has been compiled.
I've changed the regexes used to be compatible with either setting.